### PR TITLE
Fix for iOS 11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,9 +138,3 @@ DEPENDENCIES
   sprockets (~> 4.x)
   stripe (~> 2.0.1)
   uglifier (~> 3.1.6)
-
-RUBY VERSION
-   ruby 2.4.0p0
-
-BUNDLED WITH
-   1.14.6

--- a/app/assets/javascripts/background_video.es6
+++ b/app/assets/javascripts/background_video.es6
@@ -4,7 +4,8 @@ $(function() {
     rel: 0,
     showinfo: 0,
     loop: 0,
-    playsinline: 0,
+    playsinline: 1,
+    autoplay: 1,
     controls: 0,
     autoplay: 0
   };

--- a/app/assets/javascripts/background_video.es6
+++ b/app/assets/javascripts/background_video.es6
@@ -181,9 +181,7 @@ $(function() {
         window.addEventListener('scroll', seek_player);
       }, ({data: state}) => {
         let ended = 0, unstarted = -1;
-
-        if (state === ended || state === unstarted) hide_video();
-        else unhide_video();
+        state === ended || state === unstarted ? hide_video() : unhide_video();
       });
     } else if (player_is_initialized && !player_being_initialized) {
       player.loadVideoById(video.id);


### PR DESCRIPTION
A combination of iOS 11 video policies and changes to the embedded
player have broken the previous behavior of background videos on the
mobile site.

Previously calling seek on an unplayed YT video would display the frame
at that timestamp. Now, calling seek on an unplayed video does nothing.
Instead, seek only works and changes the video when it's already
playing.

Because inline autoplay videos are possible on iOS 11, we can just mute
the video and autoplay it in the background to get a similar effect.